### PR TITLE
[Deploy] Deploy using jekyll build instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "minima", "~> 2.5"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-data"
+  gem 'jekyll-deploy'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       webrick (~> 1.7)
     jekyll-data (1.1.1)
       jekyll (>= 3.3, < 5.0.0)
+    jekyll-deploy (0.0.2)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-gist (1.5.0)
@@ -108,6 +109,7 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.3.3)
   jekyll-data
+  jekyll-deploy
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
   minimal-mistakes-jekyll

--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,12 @@ collections:
     output: true
     permalink: /:collection/:path/
 
+deploy:
+  - touch .nojekyll
+  - git add -A
+  - 'git commit -m "Update site: `date`"'
+  - git push origin master
+
 author:
   name: "Bhavdeep Sethi"
   avatar: "/assets/images/bio-photo.jpg"


### PR DESCRIPTION
- GH pages doesn't support all jekyll themes
- Use separate build to deploy to GH pages 